### PR TITLE
pg_to_hdfs fails loudly

### DIFF
--- a/scripts/pg_to_hdfs.sh
+++ b/scripts/pg_to_hdfs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o pipefail
+set -e
+
 function stream_backup_to_hdfs() {
   
   n=1


### PR DESCRIPTION
Line 12 was failing silently when `pg_dump` couldn't connect to the database since `pipefail` wasn't set.
